### PR TITLE
Al accordion item storybook controls

### DIFF
--- a/packages/storybook/stories/va-accordion-uswds.stories.tsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import {
   getWebComponentDocs,
   componentStructure,
@@ -8,6 +7,34 @@ import {
 
 const accordionDocs = getWebComponentDocs('va-accordion');
 const accordionItem = getWebComponentDocs('va-accordion-item');
+
+const defaultValues = {
+  open: false,
+  subheader: '',
+}
+
+const defaultArgs = {
+  accordionItems: {
+    accordion1: {
+      ...defaultValues,
+      id: 'first',
+      header: 'First Amendment',
+      body: 'Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.',
+    },
+    accordion2: {
+      ...defaultValues,
+      id: 'second',
+      header: 'Second Amendment',
+      body: 'A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.',
+    },
+    accordion3: {
+      ...defaultValues,
+      id: 'third',
+      header: 'Third Amendment',
+      body: 'No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.',
+    },
+  },
+};
 
 export default {
   title: 'Components/Accordion USWDS',
@@ -19,349 +46,67 @@ export default {
       page: () => <StoryDocs storyDefault={Default} data={accordionDocs} />,
     },
   },
+  args: {
+    ...defaultArgs,
+    accordionItemHeadingLevel: 3,
+    accordionItemHeadlineSlot: false,
+    accordionItemIconSlot: false,
+    accordionItemBorder: false,
+  },
+  argTypes: {
+    ...propStructure(accordionDocs),
+    accordionItems: {
+      name: 'Accordion items - content',
+      control: { type: 'object' },
+    },
+    accordionItemBorder: {
+      name: 'Accordion items - border',
+    },
+    accordionItemHeadlineSlot: {
+      name: 'Accordion items - add headline slot',
+    },
+    accordionItemIconSlot: {
+      name: 'Accordion items - add icon slot',
+    },
+    accordionItemHeadingLevel: {
+      name: 'Accordion items - heading level',
+    },
+  },
+
 };
 
-const Template = args => (
-  <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment">
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment">
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment">
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const BorderedTemplate = args => {
+const Template = args => {
+  const accordionItems = [args.accordionItems.accordion1, args.accordionItems.accordion2, args.accordionItems.accordion3];
   return (
-    <va-accordion {...args}>
-      <va-accordion-item id="first" bordered={true} header="First Amendment">
-        <p>
-          Congress shall make no law respecting an establishment of religion, or
-          prohibiting the free exercise thereof; or abridging the freedom of
-          speech, or of the press; or the right of the people peaceably to
-          assemble, and to petition the Government for a redress of grievances.
-        </p>
-      </va-accordion-item>
-      <va-accordion-item id="second" bordered={true} header="Second Amendment">
-        <p>
-          A well regulated Militia, being necessary to the security of a free
-          State, the right of the people to keep and bear Arms, shall not be
-          infringed.
-        </p>
-      </va-accordion-item>
-      <va-accordion-item id="third" bordered={true} header="Third Amendment">
-        <p>
-          No Soldier shall, in time of peace be quartered in any house, without
-          the consent of the Owner, nor in time of war, but in a manner to be
-          prescribed by law.
-        </p>
-      </va-accordion-item>
+    <va-accordion
+      open-single={'open-single'}
+    >
+      {accordionItems.map(accordion => (
+        <va-accordion-item
+          id={accordion.id}
+          header={args.accordionItemHeadlineSlot ? undefined : accordion.header}
+          bordered={args.accordionItemBorder}
+          subheader={accordion.subheader ? accordion.subheader : undefined}
+          level={args.accordionItemHeadingLevel}
+          open={accordion.open}
+        >
+          {args.accordionItemHeadlineSlot && (
+            <h3 slot="headline">Slotted {accordion.header}</h3>
+          )}
+          {args.accordionItemIconSlot && (
+            <span slot="icon" className="vads-u-color--green">
+              <va-icon icon="info" />
+            </span>
+          )}
+
+          <p>{accordion.body}</p>
+        </va-accordion-item>
+      ))}
     </va-accordion>
   );
 };
 
-const TemplateSubheader = args => (
-  <va-accordion {...args}>
-    <va-accordion-item
-      id="first"
-      header="First Amendment"
-      subheader="Subheader"
-    >
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item
-      id="second"
-      header="Second Amendment"
-      subheader="Subheader"
-    >
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item
-      id="third"
-      header="Third Amendment"
-      subheader="Subheader"
-    >
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const TemplateIconHeaders = args => (
-  <va-accordion {...args}>
-    <va-accordion-item
-      id="first"
-      header="First Amendment"
-      subheader="Subheader"
-    >
-      <span slot="icon" className="vads-u-color--green">
-        <va-icon icon="info" />
-      </span>
-      <va-icon icon="mail" slot="subheader-icon" />
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item
-      id="second"
-      header="Second Amendment"
-      subheader="Subheader"
-    >
-      <span slot="icon" className="vads-u-color--green">
-        <va-icon icon="info" />
-      </span>
-      <va-icon icon="mail" slot="subheader-icon" />
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item
-      id="third"
-      header="Third Amendment"
-      subheader="Subheader"
-    >
-      <span slot="icon" className="vads-u-color--green">
-        <va-icon icon="info" />
-      </span>
-      <va-icon icon="mail" slot="subheader-icon" />
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const TemplateHeadlineSlot = args => (
-  <va-accordion {...args}>
-    <va-accordion-item id="first">
-      <h6 slot="headline">First Amendment</h6>
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="second">
-      <h6 slot="headline">Second Amendment</h6>
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="third">
-      <h6 slot="headline">Third Amendment</h6>
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const TemplateLevel = args => (
-  <va-accordion {...args}>
-    <va-accordion-item level={5} id="first" header="First Amendment">
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item level={5} id="second" header="Second Amendment">
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item level={5} id="third" header="Third Amendment">
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const I18nTemplate = args => {
-  const [lang, setLang] = useState('en');
-
-  useEffect(() => {
-    document.querySelector('main')?.setAttribute('lang', lang);
-  }, [lang]);
-
-  return (
-    <div>
-      <va-button onClick={e => setLang('es')} text="Español" />
-      <va-button onClick={e => setLang('en')} text="English" />
-      <va-button onClick={e => setLang('tl')} text="Tagalog" />
-      <va-accordion>
-        <va-accordion-item id="first" header="First Amendment">
-          <p>
-            Congress shall make no law respecting an establishment of religion,
-            or prohibiting the free exercise thereof; or abridging the freedom
-            of speech, or of the press; or the right of the people peaceably to
-            assemble, and to petition the Government for a redress of
-            grievances.
-          </p>
-        </va-accordion-item>
-        <va-accordion-item id="second" header="Second Amendment">
-          <p>
-            A well regulated Militia, being necessary to the security of a free
-            State, the right of the people to keep and bear Arms, shall not be
-            infringed.
-          </p>
-        </va-accordion-item>
-        <va-accordion-item id="third" header="Third Amendment">
-          <p>
-            No Soldier shall, in time of peace be quartered in any house,
-            without the consent of the Owner, nor in time of war, but in a
-            manner to be prescribed by law.
-          </p>
-        </va-accordion-item>
-      </va-accordion>
-    </div>
-  );
-};
-
-const ManyItemsTemplate = args => (
-  <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment">
-      <p>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment">
-      <p>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment">
-      <p>
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="fourth" header="Fourth Amendment">
-      <p>
-        The right of the people to be secure in their persons, houses, papers,
-        and effects, against unreasonable searches and seizures, shall not be
-        violated, and no Warrants shall issue, but upon probable cause,
-        supported by Oath or affirmation, and particularly describing the place
-        to be searched, and the persons or things to be seized.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="fifth" header="Fifth Amendment">
-      <p>
-        No person shall be held to answer for a capital, or otherwise infamous
-        crime, unless on a presentment or indictment of a Grand Jury, except in
-        cases arising in the land or naval forces, or in the Militia, when in
-        actual service in time of War or public danger; nor shall any person be
-        subject for the same offence to be twice put in jeopardy of life or
-        limb; nor shall be compelled in any criminal case to be a witness
-        against himself, nor be deprived of life, liberty, or property, without
-        due process of law; nor shall private property be taken for public use,
-        without just compensation.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="sixth" header="Sixth Amendment">
-      <p>
-        In all criminal prosecutions, the accused shall enjoy the right to a
-        speedy and public trial, by an impartial jury of the State and district
-        wherein the crime shall have been committed, which district shall have
-        been previously ascertained by law, and to be informed of the nature and
-        cause of the accusation; to be confronted with the witnesses against
-        him; to have compulsory process for obtaining witnesses in his favor,
-        and to have the Assistance of Counsel for his defence.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="seventh" header="Seventh Amendment">
-      <p>
-        In Suits at common law, where the value in controversy shall exceed
-        twenty dollars, the right of trial by jury shall be preserved, and no
-        fact tried by a jury, shall be otherwise re-examined in any Court of the
-        United States, than according to the rules of the common law.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="eighth" header="Eighth Amendment">
-      <p>
-        Excessive bail shall not be required, nor excessive fines imposed, nor
-        cruel and unusual punishments inflicted.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="ninth" header="Ninth Amendment">
-      <p>
-        The enumeration in the Constitution, of certain rights, shall not be
-        construed to deny or disparage others retained by the people.
-      </p>
-    </va-accordion-item>
-    <va-accordion-item id="tenth" header="Tenth Amendment">
-      <p>
-        The powers not delegated to the United States by the Constitution, nor
-        prohibited by it to the States, are reserved to the States respectively,
-        or to the people.
-      </p>
-    </va-accordion-item>
-  </va-accordion>
-);
-
-const defaultArgs = {
-  'bordered': false,
-  'open-single': undefined,
-};
-
 export const Default = Template.bind(null);
-Default.args = {
-  ...defaultArgs,
-};
-Default.argTypes = propStructure(accordionDocs);
 
 export const SingleSelect = Template.bind(null);
 SingleSelect.args = {
@@ -369,40 +114,47 @@ SingleSelect.args = {
   'open-single': true,
 };
 
-export const Bordered = BorderedTemplate.bind(null);
+export const Bordered = Template.bind(null);
 Bordered.args = {
-  ...defaultArgs,
-  bordered: true,
+  accordionItemBorder: true,
 };
 
-export const Subheader = TemplateSubheader.bind(null);
+const subheaderText = 'Subheader text';
+export const Subheader = Template.bind(null);
 Subheader.args = {
   ...defaultArgs,
+  accordionItems: {
+    accordion1: {
+      ...defaultArgs.accordionItems.accordion1,
+      subheader: subheaderText,
+    },
+    accordion2: {
+      ...defaultArgs.accordionItems.accordion2,
+      subheader: subheaderText,
+    },
+    accordion3: {
+      ...defaultArgs.accordionItems.accordion3,
+      subheader: subheaderText,
+    },
+  }
 };
 
-export const IconHeaders = TemplateIconHeaders.bind(null);
+export const IconHeaders = Template.bind(null);
 IconHeaders.args = {
   ...defaultArgs,
+  accordionItemIconSlot: true,
 };
 
-export const HeadlineSlot = TemplateHeadlineSlot.bind(null);
+export const HeadlineSlot = Template.bind(null);
 HeadlineSlot.args = {
   ...defaultArgs,
+  accordionItemHeadlineSlot: true,
 };
 
-export const CustomHeaderLevel = TemplateLevel.bind(null);
-CustomHeaderLevel.args = {
+export const Level = Template.bind(null);
+Level.args = {
   ...defaultArgs,
-};
-
-export const Internationalization = I18nTemplate.bind(null);
-Internationalization.args = {
-  ...defaultArgs,
-};
-
-export const ManyAccordions = ManyItemsTemplate.bind(null);
-ManyAccordions.args = {
-  ...defaultArgs,
+  accordionItemHeadingLevel: 4,
 };
 
 const PrintTemplate = args => (

--- a/packages/storybook/stories/va-accordion-uswds.stories.tsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.tsx
@@ -1,108 +1,111 @@
+import { useState, useEffect } from 'react';
 import {
   getWebComponentDocs,
-  componentStructure,
   propStructure,
   StoryDocs,
 } from './wc-helpers';
 
 const accordionDocs = getWebComponentDocs('va-accordion');
-const accordionItem = getWebComponentDocs('va-accordion-item');
 
 const defaultValues = {
+  bordered: false,
+  headerIconSlot: false,
+  headlineSlot: false,
+  level: 3,
   open: false,
   subheader: '',
-}
-
-const defaultArgs = {
-  accordionItems: {
-    accordion1: {
-      ...defaultValues,
-      id: 'first',
-      header: 'First Amendment',
-      body: 'Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.',
-    },
-    accordion2: {
-      ...defaultValues,
-      id: 'second',
-      header: 'Second Amendment',
-      body: 'A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.',
-    },
-    accordion3: {
-      ...defaultValues,
-      id: 'third',
-      header: 'Third Amendment',
-      body: 'No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.',
-    },
-  },
 };
+
+const accordionContent = [
+  {
+    ...defaultValues,
+    id: 'first',
+    header: 'First Amendment',
+    body: 'Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.',
+  },
+  {
+    ...defaultValues,
+    id: 'second',
+    header: 'Second Amendment',
+    body: 'A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.',
+  },
+  {
+    ...defaultValues,
+    id: 'third',
+    header: 'Third Amendment',
+    body: 'No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.',
+  },
+];
 
 export default {
   title: 'Components/Accordion USWDS',
   id: 'uswds/va-accordion',
-  subcomponents: componentStructure(accordionItem),
   parameters: {
     componentSubtitle: 'va-accordion web component',
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={accordionDocs} />,
     },
   },
-  args: {
-    ...defaultArgs,
-    accordionItemHeadingLevel: 3,
-    accordionItemHeadlineSlot: false,
-    accordionItemIconSlot: false,
-    accordionItemBorder: false,
-  },
   argTypes: {
     ...propStructure(accordionDocs),
     accordionItems: {
-      name: 'Accordion items - content',
+      name: 'Accordion items',
+      description: 'Array of accordion items to be displayed',
       control: { type: 'object' },
+      table: { category: 'Extras' },
     },
-    accordionItemBorder: {
-      name: 'Accordion items - border',
-    },
-    accordionItemHeadlineSlot: {
-      name: 'Accordion items - add headline slot',
-    },
-    accordionItemIconSlot: {
-      name: 'Accordion items - add icon slot',
-    },
-    accordionItemHeadingLevel: {
-      name: 'Accordion items - heading level',
+    i18n: {
+      name: 'Internationalization',
+      description: 'Adds buttons to change the language of the component',
+      control: { type: 'boolean' },
+      table: { category: 'Extras' },
     },
   },
-
+  args: {
+    accordionItems: accordionContent,
+    i18n: false,
+    'section-heading': undefined,
+  },
 };
 
 const Template = args => {
-  const accordionItems = [args.accordionItems.accordion1, args.accordionItems.accordion2, args.accordionItems.accordion3];
-  return (
-    <va-accordion
-      open-single={'open-single'}
-    >
-      {accordionItems.map(accordion => (
-        <va-accordion-item
-          id={accordion.id}
-          header={args.accordionItemHeadlineSlot ? undefined : accordion.header}
-          bordered={args.accordionItemBorder}
-          subheader={accordion.subheader ? accordion.subheader : undefined}
-          level={args.accordionItemHeadingLevel}
-          open={accordion.open}
-        >
-          {args.accordionItemHeadlineSlot && (
-            <h3 slot="headline">Slotted {accordion.header}</h3>
-          )}
-          {args.accordionItemIconSlot && (
-            <span slot="icon" className="vads-u-color--green">
-              <va-icon icon="info" />
-            </span>
-          )}
+  const [lang, setLang] = useState('en');
+  useEffect(() => {
+    document.querySelector('main')?.setAttribute('lang', lang);
+  }, [lang]);
 
-          <p>{accordion.body}</p>
-        </va-accordion-item>
-      ))}
-    </va-accordion>
+  return (
+    <>
+      {args.internationalization && (
+        <div>
+          <va-button onClick={e => setLang('es')} text="Español" />
+          <va-button onClick={e => setLang('en')} text="English" />
+          <va-button onClick={e => setLang('tl')} text="Tagalog" />
+        </div>
+      )}
+      <va-accordion {...args.props}>
+        {args.accordionItems.map(accordion => (
+          <va-accordion-item
+            id={accordion.id}
+            header={accordion.headlineSlot ? undefined : accordion.header}
+            bordered={accordion.bordered}
+            subheader={accordion.subheader ? accordion.subheader : undefined}
+            level={accordion.level}
+            open={accordion.open}
+          >
+            {accordion.headerIconSlot && (
+              <span slot="icon" className="vads-u-color--green">
+                <va-icon icon="info" />
+              </span>
+            )}
+            {accordion.headlineSlot && (
+              <h3 slot="headline">Slotted {accordion.header}</h3>
+            )}
+            <p>{accordion.body}</p>
+          </va-accordion-item>
+        ))}
+      </va-accordion>
+    </>
   );
 };
 
@@ -110,51 +113,97 @@ export const Default = Template.bind(null);
 
 export const SingleSelect = Template.bind(null);
 SingleSelect.args = {
-  ...defaultArgs,
-  'open-single': true,
+  props: {
+    'open-single': true,
+  },
 };
 
 export const Bordered = Template.bind(null);
 Bordered.args = {
-  accordionItemBorder: true,
+  accordionItems: accordionContent.map(item => ({
+    ...item,
+    bordered: true,
+  })),
 };
 
-const subheaderText = 'Subheader text';
 export const Subheader = Template.bind(null);
 Subheader.args = {
-  ...defaultArgs,
-  accordionItems: {
-    accordion1: {
-      ...defaultArgs.accordionItems.accordion1,
-      subheader: subheaderText,
-    },
-    accordion2: {
-      ...defaultArgs.accordionItems.accordion2,
-      subheader: subheaderText,
-    },
-    accordion3: {
-      ...defaultArgs.accordionItems.accordion3,
-      subheader: subheaderText,
-    },
-  }
+  accordionItems: accordionContent.map(item => ({
+    ...item,
+    subheader: 'Subheader text',
+  })),
 };
 
 export const IconHeaders = Template.bind(null);
 IconHeaders.args = {
-  ...defaultArgs,
-  accordionItemIconSlot: true,
+  accordionItems: accordionContent.map(item => ({
+    ...item,
+    headerIconSlot: true,
+  })),
 };
 
 export const HeadlineSlot = Template.bind(null);
 HeadlineSlot.args = {
-  ...defaultArgs,
-  accordionItemHeadlineSlot: true,
+  accordionItems: accordionContent.map(item => ({
+    ...item,
+    headlineSlot: true,
+  })),
 };
 
-export const Level = Template.bind(null);
-Level.args = {
-  ...defaultArgs,
-  accordionItemHeadingLevel: 4,
+export const CustomHeaderLevel = Template.bind(null);
+CustomHeaderLevel.args = {
+  accordionItems: accordionContent.map(item => ({
+    ...item,
+    level: 4,
+  })),
+};
+
+export const Internationalization = Template.bind(null);
+Internationalization.args = {
+  i18n: true,
+};
+
+export const ManyAccordions = Template.bind(null);
+ManyAccordions.args = {
+  accordionItems: [
+    ...accordionContent,
+    {
+      ...defaultValues,
+      id: 'fourth',
+      header: 'Fourth Amendment',
+      body: 'The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.',
+    },
+    {
+      ...defaultValues,
+      id: 'fifth',
+      header: 'Fifth Amendment',
+      body: 'No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.',
+    },
+    {
+      ...defaultValues,
+      id: 'sixth',
+      header: 'Third Amendment',
+      body: 'In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.',
+    },
+      {
+      ...defaultValues,
+      id: 'seventh',
+      header: 'Seventh Amendment',
+      body: 'In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.',
+    },
+    {
+      ...defaultValues,
+      id: 'Eighth',
+      header: 'Eighth Amendment',
+      body: 'Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.',
+    },
+    {
+      ...defaultValues,
+      id: 'Ninth',
+      header: 'Ninth Amendment',
+      body: 'The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.',
+    },
+  ],
 };
 
 const PrintTemplate = args => (
@@ -173,9 +222,6 @@ const PrintTemplate = args => (
 
 // todo: after upgrading to storybook 8 we can hide this story from the sidebar: https://storybook.js.org/docs/writing-stories/tags
 export const PrintAccordion = PrintTemplate.bind(null);
-PrintAccordion.args = {
-  ...defaultArgs,
-};
 PrintAccordion.parameters = {
   chromatic: {
     media: 'print',


### PR DESCRIPTION
## Chromatic
<!-- This `al-accordion-item-storybook-controls` is a placeholder for a CI job - it will be updated automatically -->
https://al-accordion-item-storybook-controls--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
